### PR TITLE
Fixed the `Dockerfile` cache issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ FROM planner AS builder
 
 COPY --from=planner /usr/purple-sector/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
 RUN rm -rf src bin/* crates/*
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Fixed the `Dockerfile` cache issue

## Description

<!--- Describe your changes in detail -->
Change the `cargo chef cook --recipe-path recipe.json` to `cargo chef cook --release --recipe-path recipe.json` to take advantage of the `docker` caching layers.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #49 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This speeds up the docker build time

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
