### PR TITLE
Dumped `chrono` for `time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,27 +45,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "api-lib"
 version = "0.1.0"
 dependencies = [
  "application",
  "axum",
- "chrono",
  "http-body-util",
  "infrastructure",
  "log",
@@ -73,6 +57,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared",
+ "time",
  "tokio",
  "tower",
 ]
@@ -266,12 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
-name = "bumpalo"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
 name = "bytemuck"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,21 +294,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-targets 0.52.0",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,12 +322,6 @@ dependencies = [
  "bytes",
  "memchr",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -482,6 +440,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -735,29 +703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,15 +782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
-dependencies = [
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1026,7 +962,6 @@ dependencies = [
  "byteorder",
  "bytes",
  "cc",
- "chrono",
  "cmake",
  "crc32fast",
  "flate2",
@@ -1044,6 +979,7 @@ dependencies = [
  "smallvec",
  "subprocess",
  "thiserror",
+ "time",
  "uuid",
  "zstd",
 ]
@@ -1077,6 +1013,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -1197,6 +1139,12 @@ name = "pkg-config"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1528,7 +1476,6 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "axum",
- "chrono",
  "derives",
  "figment",
  "log",
@@ -1538,6 +1485,7 @@ dependencies = [
  "redis",
  "serde",
  "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -1644,6 +1592,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1842,60 +1821,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,15 +1850,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.0",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -151,7 +150,6 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1266,8 +1264,6 @@ dependencies = [
  "itoa",
  "percent-encoding",
  "ryu",
- "sha1_smol",
- "socket2",
  "url",
 ]
 
@@ -1453,12 +1449,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ serde_json = "1.0.64"
 proc-macro2 = "1.0.78"
 quote = "1.0.35"
 syn = { version = "2.0.48", features = ["parsing"] }
-sea-query = { version = "0.30.7", features = ["backend-mysql"] }
+sea-query = { version = "0.30.7", default-features = false, features = ["derive", "backend-mysql"] }
 r2d2 = "0.8.10"
 mysql = { version = "25.0.0", default-features = false, features = ["minimal"] }
 mysql_common = { version = "0.32.2", default-features = false, features = ["time", "derive", "bigdecimal"] }
-redis = "0.25.3"
+redis = { version = "0.25.3", default-features = false }
 log = { version = "0.4.21", features = ["std"] }
-axum = { version = "0.7.5", features = ["json", "tokio"] }
-tokio = { version = "1", features = ["rt", "net", "macros", "rt-multi-thread"] }
+axum = { version = "0.7.5", default-features = false, features = ["json", "tokio", "query", "http1"] }
+tokio = { version = "1", default-features=false, features = ["rt", "net", "macros", "rt-multi-thread"] }
 figment = { version = "0.10.18", default-feature = false, features = ["yaml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "bin/*"]
 resolver = "2"
 
 [workspace.dependencies]
-chrono = { version = "0.4.38", features = ["serde"] }
+time = { version = "0.3.36", features = ["serde", "std", "parsing", "macros", "formatting"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.64"
 proc-macro2 = "1.0.78"
@@ -12,7 +12,7 @@ syn = { version = "2.0.48", features = ["parsing"] }
 sea-query = { version = "0.30.7", features = ["backend-mysql"] }
 r2d2 = "0.8.10"
 mysql = { version = "25.0.0", default-features = false, features = ["minimal"] }
-mysql_common = { version = "0.32.2", default-features = false, features = ["chrono", "derive", "bigdecimal"] }
+mysql_common = { version = "0.32.2", default-features = false, features = ["time", "derive", "bigdecimal"] }
 redis = "0.25.3"
 log = { version = "0.4.21", features = ["std"] }
 axum = { version = "0.7.5", features = ["json", "tokio"] }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono.workspace = true
+time.workspace = true
 log.workspace = true
 axum.workspace = true
 tokio.workspace = true

--- a/crates/api/src/tests/common/mod.rs
+++ b/crates/api/src/tests/common/mod.rs
@@ -84,5 +84,29 @@ pub fn parse_time(time: &str) -> time::Time {
 }
 
 pub fn parse_duration(duration: &str) -> time::Time {
-    time::Time::parse(duration, &shared::DURATION_FORMAT).unwrap()
+    let mut parsed = time::parsing::Parsed::new();
+    parsed
+        .parse_items(duration.as_bytes(), shared::DURATION_FORMAT)
+        .unwrap();
+    time::Time::from_hms_nano(
+        0,
+        parsed.minute().unwrap_or_default(),
+        parsed.second().unwrap_or_default(),
+        parsed.subsecond().unwrap_or_default(),
+    )
+    .unwrap()
+}
+
+pub fn parse_short_duration(duration: &str) -> time::Time {
+    let mut parsed = time::parsing::Parsed::new();
+    parsed
+        .parse_items(duration.as_bytes(), shared::SHORT_DURATION_FORMAT)
+        .unwrap();
+    time::Time::from_hms_nano(
+        0,
+        parsed.minute().unwrap_or_default(),
+        parsed.second().unwrap_or_default(),
+        parsed.subsecond().unwrap_or_default(),
+    )
+    .unwrap()
 }

--- a/crates/api/src/tests/common/mod.rs
+++ b/crates/api/src/tests/common/mod.rs
@@ -58,20 +58,14 @@ where
 }
 
 pub fn setup() -> Router {
-    let config = dbg!(infrastructure::config::Config::try_new().expect("valid config file"));
+    let config = infrastructure::config::Config::try_new().expect("valid config file");
 
     router(&config).expect("valid configuration")
 }
 
 pub async fn get(mut router: Router, uri: &str) -> Result<axum::http::Response<Body>, Infallible> {
     router
-        .call(
-            Request::builder()
-                .uri(uri)
-                .header("x-real-ip", "127.0.0.1")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .call(Request::builder().uri(uri).body(Body::empty()).unwrap())
         .await
 }
 
@@ -81,32 +75,4 @@ pub fn parse_date(date: &str) -> time::Date {
 
 pub fn parse_time(time: &str) -> time::Time {
     time::Time::parse(time, &shared::TIME_FORMAT).unwrap()
-}
-
-pub fn parse_duration(duration: &str) -> time::Time {
-    let mut parsed = time::parsing::Parsed::new();
-    parsed
-        .parse_items(duration.as_bytes(), shared::DURATION_FORMAT)
-        .unwrap();
-    time::Time::from_hms_nano(
-        0,
-        parsed.minute().unwrap_or_default(),
-        parsed.second().unwrap_or_default(),
-        parsed.subsecond().unwrap_or_default(),
-    )
-    .unwrap()
-}
-
-pub fn parse_short_duration(duration: &str) -> time::Time {
-    let mut parsed = time::parsing::Parsed::new();
-    parsed
-        .parse_items(duration.as_bytes(), shared::SHORT_DURATION_FORMAT)
-        .unwrap();
-    time::Time::from_hms_nano(
-        0,
-        parsed.minute().unwrap_or_default(),
-        parsed.second().unwrap_or_default(),
-        parsed.subsecond().unwrap_or_default(),
-    )
-    .unwrap()
 }

--- a/crates/api/src/tests/common/mod.rs
+++ b/crates/api/src/tests/common/mod.rs
@@ -75,10 +75,14 @@ pub async fn get(mut router: Router, uri: &str) -> Result<axum::http::Response<B
         .await
 }
 
-pub fn parse_date(date: &str) -> chrono::NaiveDate {
-    chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").unwrap()
+pub fn parse_date(date: &str) -> time::Date {
+    time::Date::parse(date, &shared::DATE_FORMAT).unwrap()
 }
 
-pub fn parse_time(time: &str) -> chrono::NaiveTime {
-    chrono::NaiveTime::parse_from_str(time, "%H:%M:%S").unwrap()
+pub fn parse_time(time: &str) -> time::Time {
+    time::Time::parse(time, &shared::TIME_FORMAT).unwrap()
+}
+
+pub fn parse_duration(duration: &str) -> time::Time {
+    time::Time::parse(duration, &shared::DURATION_FORMAT).unwrap()
 }

--- a/crates/api/src/tests/common/models.rs
+++ b/crates/api/src/tests/common/models.rs
@@ -1,6 +1,6 @@
 use shared::prelude::*;
 
-use super::{parse_date, parse_duration, parse_time};
+use super::{parse_date, parse_duration, parse_short_duration, parse_time};
 
 #[derive(Debug)]
 pub struct StaticCircuit<'a> {
@@ -220,7 +220,7 @@ impl PartialEq<PitStop> for StaticPitStop<'_> {
             && self.lap == other.lap
             && self.stop == other.stop
             && time == other.time
-            && self.duration.map(parse_duration) == other.duration
+            && self.duration.map(parse_short_duration) == other.duration
     }
 }
 

--- a/crates/api/src/tests/common/models.rs
+++ b/crates/api/src/tests/common/models.rs
@@ -1,6 +1,6 @@
 use shared::prelude::*;
 
-use super::{parse_date, parse_duration, parse_short_duration, parse_time};
+use super::{parse_date, parse_time};
 
 #[derive(Debug)]
 pub struct StaticCircuit<'a> {
@@ -220,7 +220,7 @@ impl PartialEq<PitStop> for StaticPitStop<'_> {
             && self.lap == other.lap
             && self.stop == other.stop
             && time == other.time
-            && self.duration.map(parse_short_duration) == other.duration
+            && self.duration == other.duration.as_deref()
     }
 }
 
@@ -248,7 +248,7 @@ impl PartialEq<LapTiming> for StaticTiming<'_> {
     fn eq(&self, other: &LapTiming) -> bool {
         self.driver_ref == other.driver_ref
             && self.position == other.position
-            && self.time.map(parse_duration) == other.time
+            && self.time == other.time.as_deref()
     }
 }
 

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono.workspace = true
+time.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 r2d2.workspace = true

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -8,3 +8,12 @@ pub mod prelude {
     pub use crate::parameters::*;
     pub use crate::responses::*;
 }
+
+pub const DATE_FORMAT: &[time::format_description::BorrowedFormatItem<'_>] =
+    time::macros::format_description!("[year]-[month]-[day]");
+pub const TIME_FORMAT: &[time::format_description::BorrowedFormatItem<'_>] =
+    time::macros::format_description!("[hour]:[minute]:[second]");
+pub const DURATION_FORMAT: &[time::format_description::BorrowedFormatItem<'_>] =
+    time::macros::format_description!("[minute padding:none]:[second].[subsecond digits:3]");
+pub const SHORT_DURATION_FORMAT: &[time::format_description::BorrowedFormatItem<'_>] =
+    time::macros::format_description!("[second].[subsecond digits:3]");

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -13,7 +13,3 @@ pub const DATE_FORMAT: &[time::format_description::BorrowedFormatItem<'_>] =
     time::macros::format_description!("[year]-[month]-[day]");
 pub const TIME_FORMAT: &[time::format_description::BorrowedFormatItem<'_>] =
     time::macros::format_description!("[hour]:[minute]:[second]");
-pub const DURATION_FORMAT: &[time::format_description::BorrowedFormatItem<'_>] =
-    time::macros::format_description!("[minute padding:none]:[second].[subsecond digits:3]");
-pub const SHORT_DURATION_FORMAT: &[time::format_description::BorrowedFormatItem<'_>] =
-    time::macros::format_description!("[second].[subsecond digits:3]");

--- a/crates/shared/src/models.rs
+++ b/crates/shared/src/models.rs
@@ -25,7 +25,7 @@ pub struct Driver {
     pub code: Option<String>,
     pub forename: String,
     pub surname: String,
-    pub dob: Option<chrono::NaiveDate>,
+    pub dob: Option<time::Date>,
     pub nationality: Option<String>,
     pub url: String,
 }
@@ -69,7 +69,7 @@ pub struct DriverStanding {
     pub code: Option<String>,
     pub forename: String,
     pub surname: String,
-    pub dob: Option<chrono::NaiveDate>,
+    pub dob: Option<time::Date>,
     pub nationality: Option<String>,
     pub url: String,
     pub points: f32,
@@ -86,9 +86,9 @@ pub struct Lap {
     #[mysql(rename = "raceName")]
     pub race_name: String,
     #[mysql(rename = "raceDate")]
-    pub race_date: chrono::NaiveDate,
+    pub race_date: time::Date,
     #[mysql(rename = "raceTime")]
-    pub race_time: Option<chrono::NaiveTime>,
+    pub race_time: Option<time::Time>,
     #[mysql(rename = "raceUrl")]
     pub race_url: Option<String>,
     #[mysql(rename = "circuitRef")]
@@ -111,7 +111,8 @@ pub struct Lap {
     pub driver_ref: String,
     pub lap: i32,
     pub position: Option<i32>,
-    pub time: Option<String>,
+    #[mysql(with = "try_as_duration")]
+    pub time: Option<time::Time>,
 }
 
 #[derive(FromRow, Debug)]
@@ -119,9 +120,9 @@ pub struct PitStop {
     #[mysql(rename = "raceName")]
     pub race_name: String,
     #[mysql(rename = "raceDate")]
-    pub race_date: chrono::NaiveDate,
+    pub race_date: time::Date,
     #[mysql(rename = "raceTime")]
-    pub race_time: Option<chrono::NaiveTime>,
+    pub race_time: Option<time::Time>,
     #[mysql(rename = "raceUrl")]
     pub race_url: Option<String>,
     #[mysql(rename = "circuitRef")]
@@ -144,8 +145,9 @@ pub struct PitStop {
     pub driver_ref: String,
     pub stop: i32,
     pub lap: i32,
-    pub time: chrono::NaiveTime,
-    pub duration: Option<String>,
+    pub time: time::Time,
+    #[mysql(with = "try_as_short_duration")]
+    pub duration: Option<time::Time>,
 }
 
 #[derive(FromRow, Debug)]
@@ -155,21 +157,21 @@ pub struct Race {
     #[mysql(rename = "raceName")]
     pub race_name: String,
     #[mysql(rename = "date")]
-    pub race_date: chrono::NaiveDate,
+    pub race_date: time::Date,
     #[mysql(rename = "time")]
-    pub race_time: Option<chrono::NaiveTime>,
+    pub race_time: Option<time::Time>,
     #[mysql(rename = "raceUrl")]
     pub race_url: Option<String>,
-    pub fp1_date: Option<chrono::NaiveDate>,
-    pub fp1_time: Option<chrono::NaiveTime>,
-    pub fp2_date: Option<chrono::NaiveDate>,
-    pub fp2_time: Option<chrono::NaiveTime>,
-    pub fp3_date: Option<chrono::NaiveDate>,
-    pub fp3_time: Option<chrono::NaiveTime>,
-    pub quali_date: Option<chrono::NaiveDate>,
-    pub quali_time: Option<chrono::NaiveTime>,
-    pub sprint_date: Option<chrono::NaiveDate>,
-    pub sprint_time: Option<chrono::NaiveTime>,
+    pub fp1_date: Option<time::Date>,
+    pub fp1_time: Option<time::Time>,
+    pub fp2_date: Option<time::Date>,
+    pub fp2_time: Option<time::Time>,
+    pub fp3_date: Option<time::Date>,
+    pub fp3_time: Option<time::Time>,
+    pub quali_date: Option<time::Date>,
+    pub quali_time: Option<time::Time>,
+    pub sprint_date: Option<time::Date>,
+    pub sprint_time: Option<time::Time>,
 
     #[mysql(rename = "circuitRef")]
     pub circuit_ref: String,
@@ -194,4 +196,58 @@ pub struct Status {
     pub status_id: i32,
     pub status: String,
     pub count: i32,
+}
+
+fn try_as_duration(
+    value: mysql_common::Value,
+) -> Result<Option<time::Time>, mysql_common::FromValueError> {
+    use mysql_common::Value::*;
+
+    match value {
+        Bytes(bytes) => {
+            // SAFETY: values are stored this way in the database so it should
+            // never panic
+            let mut parsed = time::parsing::Parsed::new();
+            parsed.parse_items(&bytes, super::DURATION_FORMAT).unwrap();
+            Ok(Some(
+                time::Time::from_hms_nano(
+                    0,
+                    parsed.minute().unwrap_or_default(),
+                    parsed.second().unwrap_or_default(),
+                    parsed.subsecond().unwrap_or_default(),
+                )
+                .unwrap(),
+            ))
+        }
+        NULL => Ok(None),
+        _ => Err(mysql_common::FromValueError(value)),
+    }
+}
+
+fn try_as_short_duration(
+    value: mysql_common::Value,
+) -> Result<Option<time::Time>, mysql_common::FromValueError> {
+    use mysql_common::Value::*;
+
+    match value {
+        Bytes(bytes) => {
+            // SAFETY: values are stored this way in the database so it should
+            // never panic
+            let mut parsed = time::parsing::Parsed::new();
+            parsed
+                .parse_items(&bytes, super::SHORT_DURATION_FORMAT)
+                .unwrap();
+            Ok(Some(
+                time::Time::from_hms_nano(
+                    0,
+                    parsed.minute().unwrap_or_default(),
+                    parsed.second().unwrap_or_default(),
+                    parsed.subsecond().unwrap_or_default(),
+                )
+                .unwrap(),
+            ))
+        }
+        NULL => Ok(None),
+        _ => Err(mysql_common::FromValueError(value)),
+    }
 }

--- a/crates/shared/src/parameters.rs
+++ b/crates/shared/src/parameters.rs
@@ -31,9 +31,7 @@ macros::query_parameters! {
 
 impl Year {
     pub fn get_current_year() -> Self {
-        use chrono::Datelike;
-
-        let now = chrono::Utc::now();
+        let now = time::OffsetDateTime::now_utc();
         Self(now.year() as u32)
     }
 }

--- a/crates/shared/src/responses.rs
+++ b/crates/shared/src/responses.rs
@@ -4,12 +4,10 @@ use time::serde;
 use crate::error;
 use crate::error::Result;
 use crate::parameters::Series;
-use crate::{DATE_FORMAT, DURATION_FORMAT, SHORT_DURATION_FORMAT, TIME_FORMAT};
+use crate::{DATE_FORMAT, TIME_FORMAT};
 
 serde::format_description!(date_format, Date, DATE_FORMAT);
 serde::format_description!(time_format, Time, TIME_FORMAT);
-serde::format_description!(duration_format, Time, DURATION_FORMAT);
-serde::format_description!(short_duration_format, Time, SHORT_DURATION_FORMAT);
 
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct Pagination {
@@ -24,7 +22,7 @@ pub struct Response<T> {
     pub data: T,
 
     #[serde(flatten)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub pagination: Option<Pagination>,
     pub series: Series,
 }
@@ -114,10 +112,12 @@ pub enum Standings {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LapsResponse {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub url: Option<String>,
     pub race_name: String,
     #[serde(with = "date_format")]
     pub date: time::Date,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     #[serde(with = "time_format::option")]
     pub time: Option<time::Time>,
 
@@ -128,10 +128,12 @@ pub struct LapsResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PitStopsResponse {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub url: Option<String>,
     pub race_name: String,
     #[serde(with = "date_format")]
     pub date: time::Date,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     #[serde(with = "time_format::option")]
     pub time: Option<time::Time>,
 
@@ -147,13 +149,23 @@ pub struct Race {
     pub name: String,
     #[serde(with = "date_format")]
     pub date: time::Date,
-    #[serde(with = "time_format::option")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "time_format::option",
+        default
+    )]
     pub time: Option<time::Time>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fp1: Option<DateAndTime>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fp2: Option<DateAndTime>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fp3: Option<DateAndTime>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub quali: Option<DateAndTime>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub sprint: Option<DateAndTime>,
 }
 
@@ -161,10 +173,15 @@ pub struct Race {
 pub struct Circuit {
     pub circuit_ref: String,
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub location: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub country: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub lat: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub lng: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub alt: Option<i32>,
     pub url: String,
 }
@@ -172,12 +189,19 @@ pub struct Circuit {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Driver {
     pub driver_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub number: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub code: Option<String>,
     pub forename: String,
     pub surname: String,
-    #[serde(with = "date_format::option")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "date_format::option",
+        default
+    )]
     pub dob: Option<time::Date>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub nationality: Option<String>,
     pub url: String,
 }
@@ -186,6 +210,7 @@ pub struct Driver {
 pub struct Constructor {
     pub constructor_ref: String,
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub nationality: Option<String>,
     pub url: String,
 }
@@ -193,7 +218,9 @@ pub struct Constructor {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Standing {
     pub points: f32,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub position: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub position_text: Option<String>,
     pub wins: i32,
 }
@@ -215,9 +242,10 @@ pub struct Lap {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LapTiming {
     pub driver_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub position: Option<i32>,
-    #[serde(with = "duration_format::option")]
-    pub time: Option<time::Time>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub time: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -227,8 +255,8 @@ pub struct PitStop {
     pub stop: i32,
     #[serde(with = "time_format")]
     pub time: time::Time,
-    #[serde(with = "short_duration_format::option")]
-    pub duration: Option<time::Time>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub duration: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       context: resources/dockerfiles/database
     command: --default-authentication-plugin=mysql_native_password
     restart: always
+    ports:
+      - "3306:3306"
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
@@ -20,6 +22,8 @@ services:
       memlock: -1
     volumes:
       - dragonflydata:/data
+    ports:
+      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
       timeout: 20s


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Dumped `chrono` for `time`

## Description

<!--- Describe your changes in detail -->
Removed `chrono` from the dependencies to replace it by the `time` crate. This helped reducing the dependencies number and resolved the issue warning from `cargo audit`. However, it's not possible to resolve the vulnerability since we depend on the `axum` crate.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #52 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)
